### PR TITLE
fix: remove repeated 'the' in comments

### DIFF
--- a/cpp/src/phonenumbers/phonenumbermatch.h
+++ b/cpp/src/phonenumbers/phonenumbermatch.h
@@ -41,7 +41,7 @@
 // string subsequence = text.substr(match.start(), match.end());
 // "+1 425 882-8080" == subsequence;
 //
-// // number() returns the the same result as PhoneNumberUtil::Parse()
+// // number() returns the same result as PhoneNumberUtil::Parse()
 // // invoked on raw_string().
 // const PhoneNumberUtil& util = *PhoneNumberUtil::GetInstance();
 // util.Parse(match.raw_string(), country).Equals(match.number());

--- a/java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/FlyweightMapStorage.java
+++ b/java/internal/prefixmapper/src/com/google/i18n/phonenumbers/prefixmapper/FlyweightMapStorage.java
@@ -213,7 +213,7 @@ final class FlyweightMapStorage extends PhonePrefixMapStorageStrategy {
    * @param objectOutput  the object output stream to which the value is written
    * @param wordSize  the number of bytes used to store the value
    * @param inputBuffer  the byte buffer from which the value is read
-   * @param index  the index of the value in the the byte buffer
+   * @param index  the index of the value in the byte buffer
    * @throws IOException if an error occurred writing to the provided object output stream
    */
   private static void writeExternalWord(ObjectOutput objectOutput, int wordSize,

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberMatch.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
  * CharSequence subsequence = text.subSequence(m.start(), m.end());
  * "+1 425 882-8080".contentEquals(subsequence);
  *
- * // number() returns the the same result as PhoneNumberUtil.{@link PhoneNumberUtil#parse parse()}
+ * // number() returns the same result as PhoneNumberUtil.{@link PhoneNumberUtil#parse parse()}
  * // invoked on rawString().
  * util.parse(m.rawString(), country).equals(m.number());
  * </pre>

--- a/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/finitestatematcher/DigitSequenceMatcher.java
+++ b/metadata/src/main/java/com/google/i18n/phonenumbers/metadata/finitestatematcher/DigitSequenceMatcher.java
@@ -45,7 +45,7 @@ public abstract class DigitSequenceMatcher {
     TOO_SHORT,
     /**
      * The match operation failed due to the existence of additional input after matching had
-     * completed (ie, the the input would have matched if it were shorter).
+     * completed (ie, the input would have matched if it were shorter).
      */
     TOO_LONG;
   }


### PR DESCRIPTION
## Summary
- fix repeated "the" typos in several comments across the codebase

## Testing
- `grep -R "the the" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684382a2e7a083289a5e8a62059a51b6